### PR TITLE
Add wx8.qq.com to domain list

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,7 +4,7 @@ let wechatHeaders = {
   "client-version": "2.0.0",
 };
 
-let wechatUrls = ["https://wx.qq.com/*", "https://web.wechat.com/*", "https://wx2.qq.com/*"];
+let wechatUrls = ["https://wx.qq.com/*", "https://web.wechat.com/*", "https://wx2.qq.com/*", "https://wx8.qq.com/*"];
 
 chrome.webRequest.onBeforeRequest.addListener(
   function (details) {

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
     "webRequestBlocking",
     "https://wx.qq.com/*",
     "https://web.wechat.com/*",
-    "https://wx2.qq.com/*"
+    "https://wx2.qq.com/*",
+    "https://wx8.qq.com/*"
   ],
 
   "background": {


### PR DESCRIPTION
添加一个网页版的域名wx8.qq.com

注：微信网页版走哪个域名与登录的微信账号在哪个服务器有关，登录后会自动跳转到对应的域名

- sh - wx.qq.com
- hk - web.wechat.com
- sz - wx2.qq.com
- ml - wx8.qq.com
- sg - （无）


若要查看自己的微信账号所在的服务器，可以在任何一个加群确认页面下拉页面或点击右上角三个点查看该页面的域名：

- support.weixin.qq.com - sh
- hksupport.weixin.qq.com - hk
- szsupport.weixin.qq.com - sz
- mlsupport.weixin.qq.com - ml
- support.wechat.com - sg

也可通过抓包查看微信网络连接获得。